### PR TITLE
macOS base-image deploy + obuilder cache-clear playbooks and HOWTO

### DIFF
--- a/HOWTO-base-images.md
+++ b/HOWTO-base-images.md
@@ -1,0 +1,268 @@
+# HOWTO: Update the macOS OCaml base images
+
+How to add a new OCaml base image (e.g. 5.5.0) and/or replace an existing one
+(e.g. 4.14.3 → 4.14.4) across the macOS OCluster workers, without wiping the
+ZFS pool. Driven one worker at a time so the pools keep serving jobs.
+
+## Background
+
+Each macOS worker keeps a set of per-OCaml-version base images as ZFS datasets:
+
+```
+obuilder/base-image/macos-homebrew-ocaml-<short>          # e.g. 4.14, 5.4, 5.5
+obuilder/base-image/macos-homebrew-ocaml-<short>/brew     # the Homebrew tree
+obuilder/base-image/macos-homebrew-ocaml-<short>/home     # /Users/mac1000 with the opam switch
+obuilder/base-image/macos-homebrew                        # clone of the DEFAULT version
+obuilder/base-image/busybox                               # busybox base
+```
+
+Key facts:
+
+- **The `base-image` role keys on the *short* version** (`major.minor`), e.g.
+  `4.14`. Installing **4.14.4 destroys and rebuilds** the existing `4.14`
+  dataset (which held 4.14.3). Installing **5.5.0 creates a brand-new `5.5`**
+  dataset (additional). The patch number only changes which OCaml the switch
+  is built with; the dataset name is unchanged.
+- The role is **not idempotent** — it deletes user `mac1000` and its home at the
+  end, so re-running always rebuilds from scratch.
+- **The default image** is whichever version was installed with `default: true`;
+  it is cloned to `obuilder/base-image/macos-homebrew`. Currently **5.4**. Leave
+  this alone unless you intend to change the cluster-wide default.
+- ZFS binaries live at `$HOME/zfs/bin` on every worker. The admin cap is
+  `~/admin.cap` on the control host.
+
+### Workers and pools
+
+| Pool            | Workers                                            |
+|-----------------|----------------------------------------------------|
+| `macos-arm64`   | m1-worker-01, m1-worker-02, m1-worker-03, m1-worker-04 |
+| `macos-x86_64`  | i7-worker-01, i7-worker-02, i7-worker-03, i7-worker-04 |
+
+The inventory (`hosts`) lists them as `<name>.macos.ci.dev`.
+
+## The playbook
+
+`deploy-base-images.yml` is the **non-destructive** deploy (it does NOT recreate
+the zpool — contrast with `update-ocluster.yml`, which wipes everything). For
+one worker it: `pause --wait` → `launchctl unload` ocluster → run `base-image`
+for **5.5.0** (`default: false`) → conditionally **4.14.4** (`default: false`) →
+`launchctl load` → `unpause`.
+
+Edit the `version:` values in the playbook for whatever you are deploying this
+round. The 4.14.4 step is gated by `install_4144` (default `true`) so you can
+skip it on workers that already have the new image.
+
+## Procedure
+
+### 1. Survey the current state
+
+List the pools and see which workers are idle (prefer idle ones first — then
+`pause --wait` returns immediately instead of draining a running job):
+
+```shell
+ocluster-admin -c ~/admin.cap show macos-arm64
+ocluster-admin -c ~/admin.cap show macos-x86_64
+```
+
+The dataset name can't tell you 4.14.3 from 4.14.4 (both are `4.14`). Use the
+**snapshot creation date** to see which workers already have the new build:
+
+```shell
+for w in m1-worker-01 m1-worker-02 m1-worker-03 m1-worker-04 \
+         i7-worker-01 i7-worker-02 i7-worker-03 i7-worker-04; do
+  echo "===== $w ====="
+  ssh $w 'PATH=$HOME/zfs/bin:$PATH zfs list -o name,creation -r obuilder/base-image \
+          2>/dev/null | grep -E "ocaml-[0-9]" | grep -vE "/brew|/home"'
+done
+```
+
+Note which workers already carry the target patch version — you'll pass
+`-e install_4144=false` for those.
+
+> SSH to the workers goes through a jump host (`109.74.248.109`). Connecting to
+> all 8 FQDNs in parallel (e.g. a plain `ansible all ...`) overwhelms it and
+> times out with "banner exchange" errors. Use the short names (`ssh m1-worker-01`,
+> which the `~/.ssh/config` `??-worker-??` rule proxies) and work **one worker at
+> a time**.
+
+### 2. Set the versions in the playbook
+
+Edit `deploy-base-images.yml` so the two `base-image` blocks have the versions
+you want this round (e.g. bump `5.5.0`, and the replacement patch `4.14.4`).
+Confirm the version actually exists in opam-repository before relying on it —
+the build will fail late if the switch can't be resolved.
+
+### 3. Deploy, one worker at a time
+
+Idle worker that needs both images:
+
+```shell
+ansible-playbook deploy-base-images.yml --limit i7-worker-03.macos.ci.dev
+```
+
+Worker that already has the new 4.14 (skip the 4.14 rebuild):
+
+```shell
+ansible-playbook deploy-base-images.yml --limit m1-worker-03.macos.ci.dev -e install_4144=false
+```
+
+Each worker takes roughly:
+- image build: ~10–15 min for one image (5.5.0 only), ~30–50 min for both;
+- **plus** the obuilder cache clear at the end (see step 4) — this destroys
+  `obuilder/result`, which on a long-running worker is 100+ GB and can take
+  **~1 hour** (~2–3 GB/min, per-snapshot `.zfs/snapshot` unmounts). So budget
+  roughly 1–1.5 h of worker downtime per worker. The playbook runs the destroy
+  asynchronously and polls, so a flaky SSH connection through the jump host
+  won't abort it.
+
+`pause --wait` only waits for the **one in-flight job** to finish (not the whole
+queue), then the build starts. A clean run ends with `failed=0` in the PLAY
+RECAP. (You'll see ~35 "skipping" lines when `install_4144=false` — that's the
+whole 4.14.4 role being skipped, which is correct. Both role invocations show
+"for 5.5" in their task names; that's a static `import_role` display quirk, not
+a bug — trust the ZFS ground truth in step 5.)
+
+To process several in sequence, loop and **abort on the first failure** so a
+problem doesn't cascade:
+
+```shell
+for w in m1-worker-04 i7-worker-01 i7-worker-02; do
+  echo "=== $w ==="
+  ansible-playbook deploy-base-images.yml --limit "$w.macos.ci.dev" || { echo "ABORT: $w"; break; }
+done
+```
+
+You can safely run **two** deploys concurrently (e.g. recover one worker while
+another loop runs) — just don't fan out to all 8 at once (jump host).
+
+### 4. obuilder cache clear (automatic — but understand it)
+
+`deploy-base-images.yml` does this for you at the end of every run; you don't
+run anything extra. **It is the step that, if skipped, breaks the whole fleet**,
+so understand why it's there: rebuilding the `obuilder/base-image/*` datasets
+alone does nothing, because obuilder identifies a `FROM macos-homebrew-ocaml-4.14`
+base by **name** and keeps reusing its previously-imported layers and cached
+results in `obuilder/result` / `obuilder/state`. Builds then silently get the
+**old compiler** (e.g. 4.14.2 instead of the 4.14.4 you just installed), and
+because the old result datasets predate the brew/home sub-volume layout, every
+build dies with:
+
+```
+zfs set mountpoint=/Users/mac1000 obuilder/result/<hash>/home failed with exit status 1
+   -> cannot open 'obuilder/result/<hash>/home': dataset does not exist
+```
+
+(`update-ocluster.yml` never hits this only because it destroys the entire
+zpool, which wipes the results too.)
+
+The deploy playbook therefore destroys — while the worker service is stopped —
+**only** `obuilder/result`, `result-tmp`, `state`, and `cache-tmp` (exact
+top-level name match; it never touches `obuilder/base-image` or
+`obuilder/cache`). On restart obuilder recreates those datasets and re-imports
+the current base images. `obuilder/cache` (the Homebrew + opam download caches)
+is deliberately kept so the first rebuilds aren't starting cold.
+
+Standalone recovery: if you ever need to clear the cache **without**
+re-deploying images (e.g. to recover a fleet that was deployed before this step
+existed), run the same logic on its own, one worker at a time:
+
+```shell
+ansible-playbook clean-obuilder-cache.yml --limit i7-worker-01.macos.ci.dev
+```
+
+Either way the destroy of `obuilder/result` is slow (100+ GB, ~1 h). The
+playbooks run it asynchronously and poll for completion. If you ever do it by
+hand over SSH, run it detached/in the background — a foreground shell with a
+short timeout gets killed mid-destroy and leaves the worker stopped with
+`result` half-gone (just re-run to finish). You can clear several workers in
+parallel (one brief SSH each won't stress the jump host).
+
+### 5. Verify
+
+Confirm every worker has the new 5.5 image and a freshly-dated 4.14 (= 4.14.4),
+and that they're all back in the pool, unpaused, none disconnected:
+
+```shell
+for w in m1-worker-01 m1-worker-02 m1-worker-03 m1-worker-04 \
+         i7-worker-01 i7-worker-02 i7-worker-03 i7-worker-04; do
+  echo "===== $w ====="
+  ssh $w 'PATH=$HOME/zfs/bin:$PATH zfs list -o name,creation -r obuilder/base-image \
+          2>/dev/null | grep -E "ocaml-[0-9]" | grep -vE "/brew|/home"'
+done
+
+ocluster-admin -c ~/admin.cap show macos-arm64
+ocluster-admin -c ~/admin.cap show macos-x86_64
+```
+
+## Troubleshooting
+
+### `pause --wait` hangs forever / worker stuck on a ZFS unmount deadlock
+
+Symptom: a worker shows `(N running)` for hours and never drains; `pause --wait`
+blocks. On the host you'll find a storm of stuck `zfs unmount` / `diskutil
+unmount` / `/sbin/umount` processes against `.zfs/snapshot/snap/` automounts,
+with **one process in state `U` (uninterruptible kernel wait)** — this is the
+OpenZFS-on-macOS snapshot-unmount deadlock (obuilder pruning result snapshots).
+The `obuilder` zpool itself stays `ONLINE` / no errors — it is **not** pool
+corruption. The wedged process inherits the worker's scheduler socket, so the
+scheduler keeps counting the job even after you stop the service.
+
+Diagnose:
+
+```shell
+ssh <worker> 'ps -axo pid,state,etime,command | grep -iE "/zfs |diskutil|umount" | grep -v grep'
+ssh <worker> 'sudo lsof -nP -i :8103'                 # which PID holds the scheduler socket
+ssh <worker> 'PATH=$HOME/zfs/bin:$PATH sudo zpool status obuilder'   # confirm ONLINE
+```
+
+A `U`-state process cannot be killed — **only a reboot clears it**:
+
+```shell
+ssh <worker> 'sudo launchctl unload /Library/LaunchDaemons/com.tarides.ocluster.worker.plist'
+ssh <worker> 'sudo shutdown -r now'
+```
+
+After it comes back (wait ~30–60 s — checking too early shows
+`cannot open 'obuilder': no such pool` while the pool is still importing):
+
+```shell
+ssh <worker> 'PATH=$HOME/zfs/bin:$PATH sudo zpool status obuilder'   # ONLINE, images intact
+```
+
+On reconnect the scheduler reconciles the phantom job back to `(0 running)`; the
+worker returns admin-paused if it was paused — no `forget` needed. Then just run
+the deploy playbook on it as normal. (`timeout` is not installed on the macOS
+hosts; they run zsh — rely on `ssh -o ConnectTimeout=...` to bound a hung command.)
+
+### Every build fails with `.../home: dataset does not exist`, or uses the wrong compiler
+
+Symptom: after a base-image deploy, all builds on a worker fail with
+`zfs set mountpoint=/Users/mac1000 obuilder/result/<hash>/home failed with exit
+status 1` (the real error, hidden behind "exit status 1", is
+`cannot open '.../home': dataset does not exist`); and/or a build reports an
+older OCaml (e.g. 4.14.2) than the base image you installed. The base image on
+disk is correct — confirm with:
+
+```shell
+ssh <worker> 'PATH=$HOME/zfs/bin:$PATH zfs list -o name,creation -r obuilder/base-image | grep ocaml'
+```
+
+Cause: obuilder is reusing **stale cached imports / results** because the
+non-destructive deploy didn't clear them. Fix = step 4 above
+(`clean-obuilder-cache.yml`). You can see it in the worker log
+(`/Users/administrator/ocluster.log`): obuilder clones an old `obuilder/result/<hash>`
+that has no `/home` child (`zfs list -r obuilder/result/<hash>` shows only the
+dataset itself, no `brew`/`home`), then fails setting the home mountpoint.
+
+## Notes
+
+- The older `5.3` image is still present on workers that haven't been fully
+  rebuilt via `update-ocluster.yml`. This deploy doesn't remove it; it's a
+  harmless extra image. Remove it explicitly if you want it gone:
+  `zfs destroy -R obuilder/base-image/macos-homebrew-ocaml-5.3`.
+- To change the cluster-wide **default** OCaml version, set `default: true` on
+  that version's `base-image` block (it re-clones `macos-homebrew`). Only one
+  version should be the default.
+- `update-ocluster.yml` is the heavier, **destructive** alternative: it recreates
+  the whole zpool and rebuilds from scratch (loses all cached results). Use that
+  only when the pool needs rebuilding, not for a routine image bump.

--- a/clean-obuilder-cache.yml
+++ b/clean-obuilder-cache.yml
@@ -1,0 +1,56 @@
+---
+
+# Clear obuilder's build cache so it re-imports the current base images.
+#
+# Why: deploy-base-images.yml is non-destructive (it does not wipe the zpool),
+# so obuilder keeps its previously-imported base-image layers and cached
+# results. After a base-image bump those cached layers are stale — builds reuse
+# the OLD compiler (e.g. 4.14.2 instead of 4.14.4) and, because the old result
+# datasets predate the brew/home sub-volume layout, obuilder fails with
+# `zfs set mountpoint=/Users/mac1000 .../home: dataset does not exist`.
+# (update-ocluster.yml avoided this by destroying the whole pool.)
+#
+# This destroys ONLY obuilder's result/result-tmp/state/cache-tmp datasets
+# (exact top-level name match), forcing obuilder to recreate them and re-import
+# the base images on restart. It PRESERVES obuilder/base-image (the images) and
+# obuilder/cache (the homebrew + opam download caches).
+#
+# Run one worker at a time, e.g.:
+#   ansible-playbook clean-obuilder-cache.yml --limit i7-worker-01.macos.ci.dev
+
+- hosts: all
+  serial: 1
+  vars:
+    zfs: "{{ ansible_env.HOME }}/zfs/bin/zfs"
+  tasks:
+  - name: Pause the worker
+    shell: ocluster-admin -c ~/admin.cap pause macos-{{ ansible_architecture }} {{ inventory_hostname_short }}
+    delegate_to: 127.0.0.1
+
+  - name: Stop ocluster via launchctl
+    shell: launchctl unload /Library/LaunchDaemons/com.tarides.ocluster.worker.plist
+    become: yes
+    register: launchctl_check
+    failed_when: not ( launchctl_check.rc == 134 or launchctl_check.rc == 0 )
+
+  - name: Find obuilder cache/result datasets to destroy (exact top-level names only)
+    shell: "{{ zfs }} list -H -o name -d 1 obuilder | grep -E 'obuilder/(result|result-tmp|state|cache-tmp)$' || true"
+    register: to_destroy
+    changed_when: false
+
+  - name: Show what will be destroyed
+    debug:
+      var: to_destroy.stdout_lines
+
+  - name: Destroy stale obuilder datasets
+    shell: "{{ zfs }} destroy -r -f {{ item }}"
+    loop: "{{ to_destroy.stdout_lines }}"
+    become: yes
+
+  - name: Start ocluster via launchctl
+    shell: launchctl load /Library/LaunchDaemons/com.tarides.ocluster.worker.plist
+    become: yes
+
+  - name: Unpause the worker
+    shell: ocluster-admin -c ~/admin.cap unpause macos-{{ ansible_architecture }} {{ inventory_hostname_short }}
+    delegate_to: 127.0.0.1

--- a/deploy-base-images.yml
+++ b/deploy-base-images.yml
@@ -1,0 +1,117 @@
+---
+
+# Deploy an additional OCaml 5.5.0 base image to the macOS workers and replace
+# the 4.14.3 image with 4.14.4 where that has not already been done.
+#
+# Does NOT wipe the ZFS pool. The base-image role keys on the short version
+# (e.g. "4.14"), so installing 4.14.4 destroys and rebuilds the existing 4.14
+# dataset (4.14.3), while 5.5.0 creates a brand-new 5.5 dataset. The default
+# image (5.4 -> macos-homebrew) is left untouched.
+#
+# IMPORTANT: this playbook also clears obuilder's build cache (result /
+# result-tmp / state / cache-tmp) at the end. That step is NOT optional and is
+# why it lives here rather than in a separate playbook: rebuilding the
+# base-image datasets alone does nothing, because obuilder keys a
+# `FROM macos-homebrew-ocaml-X` base by NAME and keeps reusing its previously
+# imported layers — builds then run the OLD compiler and fail with
+# `zfs set mountpoint=/Users/mac1000 .../home: dataset does not exist`. Clearing
+# the cache forces obuilder to re-import the new base images. (base-image and
+# the homebrew/opam download cache under obuilder/cache are preserved.)
+#
+# Run one worker at a time, e.g.:
+#   ansible-playbook deploy-base-images.yml --limit i7-worker-03.macos.ci.dev
+#
+# For the two workers already carrying 4.14.4 (m1-worker-01, m1-worker-03) skip
+# the 4.14.4 rebuild:
+#   ansible-playbook deploy-base-images.yml --limit m1-worker-03.macos.ci.dev -e install_4144=false
+
+- hosts: all
+  serial: 1
+  tasks:
+  - name: Check architecture intel
+    set_fact: homebrew_prefix="/usr/local"
+    when: ansible_architecture == "x86_64"
+
+  - name: Check architecture arm
+    set_fact: homebrew_prefix="/opt/homebrew"
+    when: ansible_architecture == "arm64"
+
+  - debug:
+      var: homebrew_prefix
+
+  - name: Pause the worker
+    shell: ocluster-admin -c ~/admin.cap pause --wait macos-{{ ansible_architecture }} {{ inventory_hostname_short }}
+    delegate_to: 127.0.0.1
+
+  - name: Stop ocluster via launchctl
+    shell: launchctl unload /Library/LaunchDaemons/com.tarides.ocluster.worker.plist
+    become: yes
+    register: launchctl_check
+    failed_when: not ( launchctl_check.rc == 134 or launchctl_check.rc == 0 )
+
+  - name: Install base-image for 5.5.0
+    import_role:
+      name: base-image
+    vars:
+      version: 5.5.0
+      user_name: mac1000
+      zfs_pool: obuilder
+      default: false
+    environment:
+      PATH: '{{ ansible_env.HOME }}/zfs/bin:{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
+
+  - name: Install base-image for 4.14.4 (replaces 4.14.3)
+    import_role:
+      name: base-image
+    vars:
+      version: 4.14.4
+      user_name: mac1000
+      zfs_pool: obuilder
+      default: false
+    environment:
+      PATH: '{{ ansible_env.HOME }}/zfs/bin:{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
+    when: install_4144 | default(true) | bool
+
+  # --- Clear obuilder's build cache so it re-imports the new base images. ---
+  # Without this, obuilder keeps serving stale imported layers (old compiler)
+  # and every build fails on `.../home: dataset does not exist`.
+
+  - name: Find obuilder build-cache datasets to clear (exact top-level names only)
+    shell: "{{ ansible_env.HOME }}/zfs/bin/zfs list -H -o name -d 1 obuilder | grep -E 'obuilder/(result|result-tmp|state|cache-tmp)$' || true"
+    register: obuilder_cache
+    changed_when: false
+
+  - name: Show obuilder datasets that will be cleared (base-image and cache are NOT in this list)
+    debug:
+      var: obuilder_cache.stdout_lines
+
+  - name: Clear obuilder build cache (async — destroying obuilder/result can take ~1h on a full worker)
+    shell: |
+      zfs={{ ansible_env.HOME }}/zfs/bin/zfs
+      for ds in {{ obuilder_cache.stdout_lines | join(' ') }}; do
+        echo "destroying $ds"
+        $zfs destroy -r -f "$ds"
+      done
+    become: yes
+    async: 7200
+    poll: 0
+    register: obuilder_clear
+    when: obuilder_cache.stdout_lines | length > 0
+
+  - name: Wait for obuilder cache clear to finish (polls every 30s, up to 2h)
+    async_status:
+      jid: "{{ obuilder_clear.ansible_job_id }}"
+    register: obuilder_clear_status
+    until: obuilder_clear_status.finished
+    retries: 240
+    delay: 30
+    become: yes
+    when: obuilder_clear.ansible_job_id is defined
+
+  - name: Start ocluster via launchctl
+    shell: launchctl load /Library/LaunchDaemons/com.tarides.ocluster.worker.plist
+    become: yes
+
+  - name: Unpause the worker
+    shell: ocluster-admin -c ~/admin.cap unpause macos-{{ ansible_architecture }} {{ inventory_hostname_short }}
+    delegate_to: 127.0.0.1

--- a/update-ocluster.yml
+++ b/update-ocluster.yml
@@ -24,8 +24,12 @@
     register: launchctl_check
     failed_when: not ( launchctl_check.rc == 134 or launchctl_check.rc == 0 )
 
-  - name: Destroy ZFS pool
-    shell: "{{ ansible_env.HOME }}/zfs/bin/zpool destroy -f obuilder"
+      #  - name: Destroy ZFS pool
+      #    shell: "{{ ansible_env.HOME }}/zfs/bin/zpool destroy -f obuilder"
+      #    become: yes
+
+  - name: unmount empty (after diskutil eraseVolume ExFAT empty /dev/disk0s3)
+    shell: "umount /Volumes/empty"
     become: yes
 
   - name: Create new pool
@@ -56,33 +60,22 @@
     environment:
       PATH: '{{ ansible_env.HOME }}/zfs/bin:{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
 
-  - name: Install base-image for 4.14.2
+  - name: Install base-image for 4.14.4
     import_role:
       name: base-image
     vars:
-      version: 4.14.2
+      version: 4.14.4
       user_name: mac1000
       zfs_pool: obuilder
       default: false
     environment:
       PATH: '{{ ansible_env.HOME }}/zfs/bin:{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
 
-  - name: Install base-image for 5.3.0
+  - name: Install base-image for 5.4.1
     import_role:
       name: base-image
     vars:
-      version: 5.3.0
-      user_name: mac1000
-      zfs_pool: obuilder
-      default: false
-    environment:
-      PATH: '{{ ansible_env.HOME }}/zfs/bin:{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
-
-  - name: Install base-image for 5.4.0
-    import_role:
-      name: base-image
-    vars:
-      version: 5.4.0
+      version: 5.4.1
       user_name: mac1000
       zfs_pool: obuilder
       default: true


### PR DESCRIPTION
Adds a non-destructive way to update the macOS OCaml base images, plus the
4.14.4 / 5.4.1 base-image bump.

- **`deploy-base-images.yml`** — adds the OCaml 5.5.0 base image and replaces
  4.14.3 with 4.14.4, one worker at a time, without wiping the ZFS pool.
  Crucially it **also clears obuilder's build cache** (`result` / `result-tmp`
  / `state` / `cache-tmp`) at the end of the run, so obuilder re-imports the new
  base images.
- **`clean-obuilder-cache.yml`** — the same cache-clear as a standalone recovery
  playbook (clear the cache without re-deploying images).
- **`HOWTO-base-images.md`** — full runbook: surveying state, deploying, the
  cache-clear requirement, verification, and troubleshooting.